### PR TITLE
Allow custom erlang version for package.rb as well

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,6 @@ default['erlang']['source']['url'] = "http://erlang.org/download/otp_src_#{node[
 default['erlang']['source']['checksum'] = 'f94f7de7328af3c0cdc42089c1a4ecd03bf98ec680f47eb5e6cddc50261cabde'
 default['erlang']['source']['build_flags'] = ''
 default['erlang']['source']['cflags'] = ''
-
+default['erlang']['package']['version'] = nil
 default['erlang']['esl']['version'] = nil
 default['erlang']['esl']['lsb_codename'] = node['lsb']['codename']

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -24,8 +24,12 @@
 case node['platform_family']
 when 'debian'
   erlpkg = node['erlang']['gui_tools'] ? 'erlang-x11' : 'erlang-nox'
-  package erlpkg
-  package 'erlang-dev'
+  package erlpkg do
+    version node['erlang']['package']['version'] if node['erlang']['package']['version']
+  end
+  package 'erlang-dev' do
+    version node['erlang']['package']['version'] if node['erlang']['package']['version']
+  end
 
 when 'rhel'
   case node['platform_version'].to_i
@@ -43,5 +47,7 @@ when 'rhel'
     include_recipe 'yum-erlang_solutions'
   end
 
-  package 'erlang'
+  package 'erlang' do
+    version node['erlang']['package']['version'] if node['erlang']['package']['version']
+  end
 end


### PR DESCRIPTION
No reason this should only be allowed for the esl variant.