### PR TITLE
Add yum-epel recipe to install prereqs for erlang.

### DIFF
--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -38,7 +38,9 @@ when 'rhel'
       gpgcheck false
       action :create
     end
-
+  when 7
+    include_recipe 'yum-epel'
+    include_recipe 'yum-erlang_solutions'
   else
     include_recipe 'yum-erlang_solutions'
   end

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -28,10 +28,9 @@ when 'debian'
   package 'erlang-dev'
 
 when 'rhel'
+  include_recipe 'yum-epel'
   case node['platform_version'].to_i
   when 5
-    include_recipe 'yum-epel'
-
     yum_repository 'EPELErlangrepo' do
       description "Updated erlang yum repository for RedHat / Centos 5.x - #{node['kernel']['machine']}"
       baseurl 'http://repos.fedorapeople.org/repos/peter/erlang/epel-5Server/$basearch'
@@ -39,7 +38,6 @@ when 'rhel'
       action :create
     end
   else
-    include_recipe 'yum-epel'
     include_recipe 'yum-erlang_solutions'
   end
 

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -38,10 +38,8 @@ when 'rhel'
       gpgcheck false
       action :create
     end
-  when 7
-    include_recipe 'yum-epel'
-    include_recipe 'yum-erlang_solutions'
   else
+    include_recipe 'yum-epel'
     include_recipe 'yum-erlang_solutions'
   end
 


### PR DESCRIPTION
This fixes [issue
24](https://github.com/opscode-cookbooks/erlang/issues/24). It was
discovered that erlang requires packages(lib2x_gtk2u) present in the epel-repo in
centos-7.