### PR TITLE
Change erlang to esl-erlang in the esl.rb recipe

### DIFF
--- a/recipes/esl.rb
+++ b/recipes/esl.rb
@@ -45,7 +45,7 @@ when 'rhel'
     include_recipe 'yum-erlang_solutions'
   end
 
-  package 'erlang' do
+  package 'esl-erlang' do
     version node['erlang']['esl']['version'] if node['erlang']['esl']['version']
   end
 


### PR DESCRIPTION
If you choose the esl.rb recipe, it should install esl-erlang not erlang.